### PR TITLE
Update Squawk in list and departure tag

### DIFF
--- a/LFXX_AIRAC_2412_1/systems/default/labels.json
+++ b/LFXX_AIRAC_2412_1/systems/default/labels.json
@@ -90,7 +90,8 @@
           "fontWeight": "bold",
           "fontSize": 12,
           "leftClick": "callsignMenu",
-          "prefix": ["=assumedPrefix"]
+          "prefix": ["=assumedPrefix"],
+          "color": "=incorrectSquawkRedColor"
         },
         {
           "itemName": "acShortType",

--- a/LFXX_AIRAC_2412_1/systems/default/labels.json
+++ b/LFXX_AIRAC_2412_1/systems/default/labels.json
@@ -20,9 +20,9 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
-
           "fontWeight": "bold",
-          "fontSize": 12
+          "fontSize": 12,
+          "color": "=incorrectSquawkRedColor"
         },
         {
           "itemName": "text",

--- a/LFXX_AIRAC_2412_1/systems/expressions.json
+++ b/LFXX_AIRAC_2412_1/systems/expressions.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/neoradar-project/schemas/main/systems/expressions.schema.json",
   "rules": {
-    "incorrectSquawkColor": { "value": "239, 247, 72", "expression": ["$incorrectSquawk"] },
+    "incorrectSquawkYellowColor": { "value": "239, 247, 72", "expression": ["$incorrectSquawk"] },
+    "incorrectSquawkRedColor": { "value": "239, 20, 72", "expression": ["$incorrectSquawk"] },
+    "emptyIfNoAssignedSquawk":  {"value": "", "expression": ["$noAssignedSquawk"] },
 
     "suggestedSidIfNoAssigned": { "value": "&suggestedSid", "expression": ["$isAssignedSidEmpty"] },
     "suggestedDepRunwayIfNoAssigned": {
@@ -74,6 +76,7 @@
     "isArr": ["==", "isArrival", "1"],
 
     "incorrectSquawk": ["!=", "squawk", "&assignedSquawk"],
+    "noAssignedSquawk": ["==", "assignedSquawk", "0000"],
 
     "isAssignedSidEmpty": ["isEmpty", "sid"],
     "isAssignedDepRunwayEmpty": ["isEmpty", "depRunway"],

--- a/LFXX_AIRAC_2412_1/systems/lists.yaml
+++ b/LFXX_AIRAC_2412_1/systems/lists.yaml
@@ -129,9 +129,13 @@
     - name: assr
       width: 50
       tagItem:
-        itemName: assignedSquawk
+        itemName: text
+        value:
+          - =emptyIfNoAssignedSquawk
+          - |
+            &assignedSquawk
         placeholder: "----"
-        color: "=incorrectSquawkColor"
+        color: "=incorrectSquawkYellowColor"
         leftClick: assignRandomSquawk
         rightClick: assignSq1000
     - name: e


### PR DESCRIPTION
- Make the Squawk column in departure list empty if no Squawk is assigned
- Make the callsign red on the Departure tag if the Squawk is not set correctly