### PR TITLE
Set status column in Departure list empty if NOST

### DIFF
--- a/LFXX_AIRAC_2412_1/systems/lists.yaml
+++ b/LFXX_AIRAC_2412_1/systems/lists.yaml
@@ -160,7 +160,7 @@
       tagItem:
         itemName: groundStatus
         mapping:
-          0: "NOST"
+          0: ""
           1: "STUP"
           2: "PUSH"
           3: "TAXI"


### PR DESCRIPTION
In order to match Euroscope behavior