### PR TITLE
Add ground status on detailed departure tag

### DIFF
--- a/LFXX_AIRAC_2412_1/systems/default/labels.json
+++ b/LFXX_AIRAC_2412_1/systems/default/labels.json
@@ -114,6 +114,17 @@
       ],
       [
         {
+          "itemName": "groundStatus",
+          "leftClick": "groundStatusMenu",
+          "mapping": {
+            "0": "NOST",
+            "1": "STUP",
+            "2": "PUSH",
+            "3": "TAXI",
+            "4": "DEPA"
+          }
+        },
+        {
           "itemName": "scratchpad",
           "leftClick": "triggerScratchpad",
           "placeholder": "..."


### PR DESCRIPTION
In order quickly set the status (since selected tag is not highlighted in the lists)