### PR TITLE
Add suffix for assumed tag on ground

### DIFF
--- a/packages/LFXX_AIRAC_2412_1/systems/default/labels.json
+++ b/packages/LFXX_AIRAC_2412_1/systems/default/labels.json
@@ -6,6 +6,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12
         },
@@ -20,6 +21,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12,
           "color": "=incorrectSquawkRedColor"
@@ -53,6 +55,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12
         },
@@ -74,6 +77,7 @@
           "fontWeight": "bold",
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontSize": 12
 
         },


### PR DESCRIPTION
Change assumed tag on ground from `[AFR001` to `[AFR001]` to match Euroscope behavior