### PR TITLE
Fix LFPO arrival expression

### DIFF
--- a/packages/LFXX_AIRAC_2412_1/systems/expressions.json
+++ b/packages/LFXX_AIRAC_2412_1/systems/expressions.json
@@ -200,7 +200,7 @@
 
     "isBeauvaisDeparture": ["==", "origin", "LFOB"],
     "isBourgetArrival": ["==", "destination", "LFPB"],
-    "isOrlyArrival": ["==", "origin", "LFPO"],
+    "isOrlyArrival": ["==", "destination", "LFPO"],
 
     "isCDGOrPBDeparture": [
       "OR",


### PR DESCRIPTION
That fixes:
- The background of the callsign in the departure tag (non-detailed)
- The color of the plot