### PR TITLE
Fixed aviso display

### DIFF
--- a/package/profiles/Nice/NCE Aviso.stp
+++ b/package/profiles/Nice/NCE Aviso.stp
@@ -32,11 +32,7 @@
       },
       {
         "showLabel": false,
-        "uuid": "region-lfmn-aviso-v3"
-      },
-      {
-        "showLabel": false,
-        "uuid": "region-lfmn-aviso-coastline"
+        "uuid": "region-lfmn-aviso"
       },
       {
         "showLabel": false,


### PR DESCRIPTION
Updated UUID for region-lfmn-aviso and removed unused coastline entry.