### PR TITLE
Add missing assumed suffix in ground tags

### DIFF
--- a/package/systems/cdg/labels.json
+++ b/package/systems/cdg/labels.json
@@ -15,6 +15,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12
         },
@@ -48,6 +49,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12,
           "color": "=incorrectSquawkRedColor"
@@ -100,6 +102,7 @@
         {
           "itemName": "callsign",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontWeight": "bold",
           "fontSize": 12
         },
@@ -140,6 +143,7 @@
           "fontWeight": "bold",
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontSize": 12
 
         },
@@ -167,6 +171,7 @@
           "fontSize": 12,
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "color": "=incorrectSquawkRedColor"
         },
         {
@@ -225,7 +230,8 @@
           "fontWeight": "bold",
           "fontSize": 12,
           "leftClick": "callsignMenu",
-          "prefix": ["=assumedPrefix"]
+          "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"]
         },
         {
           "separatorBefore": true,

--- a/package/systems/default/labels.json
+++ b/package/systems/default/labels.json
@@ -154,6 +154,7 @@
           "fontSize": 12,
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "color": "=incorrectSquawkRedColor"
         },
         {
@@ -213,7 +214,8 @@
           "fontWeight": "bold",
           "fontSize": 12,
           "leftClick": "callsignMenu",
-          "prefix": ["=assumedPrefix"]
+          "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"]
         },
         {
           "separatorBefore": true,

--- a/package/systems/irma/labels.json
+++ b/package/systems/irma/labels.json
@@ -134,6 +134,7 @@
           "fontWeight": "bold",
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "fontSize": 12
         },
         {
@@ -170,6 +171,7 @@
           "fontSize": 12,
           "leftClick": "callsignMenu",
           "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"],
           "color": "=incorrectSquawkRedColor"
         },
         {
@@ -227,7 +229,8 @@
           "fontWeight": "bold",
           "fontSize": 12,
           "leftClick": "callsignMenu",
-          "prefix": ["=assumedPrefix"]
+          "prefix": ["=assumedPrefix"],
+          "suffix": ["=assumedSuffix"]
         },
         {
           "separatorBefore": true,


### PR DESCRIPTION
Add missing assumed suffix `]` in some of the ground tags.
Only the one in `default` system is really important but update everywhere missing for consistency.
